### PR TITLE
Fix recent blockchain override

### DIFF
--- a/examples/jupiterSwap.ts
+++ b/examples/jupiterSwap.ts
@@ -9,7 +9,7 @@ const JUPITER_CONFIG = {
   API_URL: 'https://quote-api.jup.ag/v6',
   WRAPPED_SOL_MINT: 'So11111111111111111111111111111111111111112',
   USDC_MINT: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-  AMOUNT_TO_SWAP: 0.1 * 10 ** 9,
+  AMOUNT_TO_SWAP: 0.05 * 10 ** 9,
   SLIPPAGE_BPS: 50,
 };
 
@@ -18,7 +18,7 @@ const connectionConfig: FireblocksConnectionAdapterConfig = {
   apiKey: process.env.FIREBLOCKS_API_KEY,
   apiSecretPath: process.env.FIREBLOCKS_SECRET_KEY_PATH,
   vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID,
-  silent: false,
+  silent: false
 };
 
 // Jupiter API Helper Functions

--- a/examples/staking.ts
+++ b/examples/staking.ts
@@ -83,3 +83,75 @@ const main = async () => {
 };
 
 main();  
+
+/*
+Another option would be - Insteaf of doing partial sign, we can just pass the stake account 
+to the sendAndConfirmTransaction function as a signer
+
+
+
+<---- CODE EXAMPLE ---->
+
+const main = async () => {
+  const transaction = new Transaction();
+  const validatorVoteAccount = "FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f";
+
+  const fireblocksConnectionConfig: FireblocksConnectionAdapterConfig = {
+    apiKey: process.env.FIREBLOCKS_API_KEY || "",
+    apiSecretPath: process.env.FIREBLOCKS_SECRET_KEY_PATH || "",
+    vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID || "",
+    feeLevel: FeeLevel.HIGH,
+    silent: false,
+    devnet: true
+  };
+
+  const connection = await FireblocksConnectionAdapter.create(
+    clusterApiUrl("devnet"),
+    fireblocksConnectionConfig,
+  );
+
+  const selectedValidatorPubkey = new PublicKey(validatorVoteAccount);
+  const accountPublicKey = new PublicKey(connection.getAccount());
+
+
+  // Create a keypair for our stake account
+  const stakeAccount = Keypair.generate();
+  console.log("stake account public key:", stakeAccount.publicKey.toBase58());
+
+  // 1. Add create account instruction
+  transaction.add(StakeProgram.createAccount({
+    authorized: new Authorized(accountPublicKey, accountPublicKey),
+    fromPubkey: accountPublicKey,
+    lamports: LAMPORTS_PER_SOL * 0.01,
+    stakePubkey: stakeAccount.publicKey,
+  }));
+
+  // 2. Add delegate instruction
+  transaction.add(StakeProgram.delegate({
+    stakePubkey: stakeAccount.publicKey,
+    authorizedPubkey: accountPublicKey,
+    votePubkey: selectedValidatorPubkey,
+  }));
+
+  connection.setTxNote(
+    "This is to create a stake account and a delegate instruction for given vault account",
+  );
+
+  try {
+    const txHash = await sendAndConfirmTransaction(connection, transaction, [stakeAccount]);
+
+    console.log(
+      `Transaction sent: https://explorer.solana.com/tx/${txHash}?cluster=devnet`,
+    );
+
+    console.log(`Stake account created. Tx Id: ${txHash}`);
+  } catch (error) {
+    console.error("Error sending transaction:", error);
+  }
+};
+
+main();  
+
+
+
+*/

--- a/examples/staking.ts
+++ b/examples/staking.ts
@@ -1,0 +1,85 @@
+import {
+  clusterApiUrl,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  StakeProgram,
+  Authorized,
+  Transaction,
+  Keypair,
+} from "@solana/web3.js";
+
+import { 
+  FireblocksConnectionAdapter, 
+  FireblocksConnectionAdapterConfig, 
+  FeeLevel } 
+from "../src";
+
+require("dotenv").config();
+
+
+
+const main = async () => {
+  const transaction = new Transaction();
+  const validatorVoteAccount = "FwR3PbjS5iyqzLiLugrBqKSa5EKZ4vK9SKs7eQXtT59f";
+
+  const fireblocksConnectionConfig: FireblocksConnectionAdapterConfig = {
+    apiKey: process.env.FIREBLOCKS_API_KEY || "",
+    apiSecretPath: process.env.FIREBLOCKS_SECRET_KEY_PATH || "",
+    vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID || "",
+    feeLevel: FeeLevel.HIGH,
+    silent: false,
+    devnet: true
+  };
+
+  const connection = await FireblocksConnectionAdapter.create(
+    clusterApiUrl("devnet"),
+    fireblocksConnectionConfig,
+  );
+
+  const selectedValidatorPubkey = new PublicKey(validatorVoteAccount);
+  const accountPublicKey = new PublicKey(connection.getAccount());
+
+  transaction.feePayer = accountPublicKey;
+  transaction.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+
+  // Create a keypair for our stake account
+  const stakeAccount = Keypair.generate();
+  console.log("stake account public key:", stakeAccount.publicKey.toBase58());
+
+  // 1. Add create account instruction
+  transaction.add(StakeProgram.createAccount({
+    authorized: new Authorized(accountPublicKey, accountPublicKey),
+    fromPubkey: accountPublicKey,
+    lamports: LAMPORTS_PER_SOL * 0.01,
+    stakePubkey: stakeAccount.publicKey,
+  }));
+
+  // 2. Add delegate instruction
+  transaction.add(StakeProgram.delegate({
+    stakePubkey: stakeAccount.publicKey,
+    authorizedPubkey: accountPublicKey,
+    votePubkey: selectedValidatorPubkey,
+  }));
+
+  connection.setTxNote(
+    "This is to create a stake account and a delegate instruction for given vault account",
+  );
+
+  //Partial sign the transaction with the stake account
+  transaction.partialSign(stakeAccount);
+
+  try {
+    const txHash = await sendAndConfirmTransaction(connection, transaction, []);
+
+    console.log(
+      `Transaction sent: https://explorer.solana.com/tx/${txHash}?cluster=devnet`,
+    );
+
+    console.log(`Stake account created. Tx Id: ${txHash}`);
+  } catch (error) {
+    console.error("Error sending transaction:", error);
+  }
+};
+
+main();  


### PR DESCRIPTION
Update the Fireblocks Adapter to not override the recent blockHash if provided.
In addition, allow the user to pass external signers array if needed to be signed by non Fireblocks accounts.