### PR TITLE
feat: add apiSecret config option for direct secret key support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 FIREBLOCKS_API_KEY="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXXX"
+# Option 1: Provide the secret key directly (useful for secrets managers like gopass, vault, etc.)
+# FIREBLOCKS_SECRET_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+# Option 2: Provide a path to the secret key file
 FIREBLOCKS_SECRET_KEY_PATH="./api_keys/fireblocks_secret.key"
 FIREBLOCKS_VAULT_ACCOUNT_ID=0

--- a/dist/FireblocksConnectionAdapter.js
+++ b/dist/FireblocksConnectionAdapter.js
@@ -73,10 +73,13 @@ class FireblocksConnectionAdapter extends web3_js_1.Connection {
         };
     }
     validateConfig(config) {
-        if (!config.apiKey || !config.apiSecretPath || !config.vaultAccountId) {
+        if (!config.apiKey || !config.vaultAccountId) {
             throw new Error('Missing required configuration parameters');
         }
-        if (!fs_1.default.existsSync(config.apiSecretPath)) {
+        if (!config.apiSecret && !config.apiSecretPath) {
+            throw new Error('Either apiSecret or apiSecretPath must be provided');
+        }
+        if (!config.apiSecret && config.apiSecretPath && !fs_1.default.existsSync(config.apiSecretPath)) {
             throw new Error(`API secret file not found at path: ${config.apiSecretPath}`);
         }
     }
@@ -94,7 +97,9 @@ class FireblocksConnectionAdapter extends web3_js_1.Connection {
                 throw new Error('Endpoint is required');
             }
             try {
-                const fireblocksSecretKey = yield fs_1.default.promises.readFile(config.apiSecretPath, "utf-8");
+                const fireblocksSecretKey = config.apiSecret
+                    ? config.apiSecret
+                    : yield fs_1.default.promises.readFile(config.apiSecretPath, "utf-8");
                 const fireblocksClient = new fireblocks_sdk_1.FireblocksSDK(fireblocksSecretKey, config.apiKey, types_1.API_BASE_URLS.PRODUCTION);
                 const adapter = new FireblocksConnectionAdapter(fireblocksClient, endpoint, config, commitment);
                 yield adapter.setAccount(config.vaultAccountId, config.devnet);

--- a/src/FireblocksConnectionAdapter.ts
+++ b/src/FireblocksConnectionAdapter.ts
@@ -68,11 +68,15 @@ export class FireblocksConnectionAdapter extends Connection {
   }
 
   private validateConfig(config: FireblocksConnectionAdapterConfig): void {
-    if (!config.apiKey || !config.apiSecretPath || !config.vaultAccountId) {
+    if (!config.apiKey || !config.vaultAccountId) {
       throw new Error('Missing required configuration parameters');
     }
-    
-    if (!fs.existsSync(config.apiSecretPath)) {
+
+    if (!config.apiSecret && !config.apiSecretPath) {
+      throw new Error('Either apiSecret or apiSecretPath must be provided');
+    }
+
+    if (!config.apiSecret && config.apiSecretPath && !fs.existsSync(config.apiSecretPath)) {
       throw new Error(`API secret file not found at path: ${config.apiSecretPath}`);
     }
   }
@@ -95,7 +99,9 @@ export class FireblocksConnectionAdapter extends Connection {
     }
 
     try {
-      const fireblocksSecretKey = await fs.promises.readFile(config.apiSecretPath, "utf-8");
+      const fireblocksSecretKey = config.apiSecret
+        ? config.apiSecret
+        : await fs.promises.readFile(config.apiSecretPath!, "utf-8");
       const fireblocksClient = new FireblocksSDK(
         fireblocksSecretKey,
         config.apiKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,25 +26,30 @@ export type AssetId = typeof ASSET_IDS[keyof typeof ASSET_IDS];
 /**
  * apiKey: string - Fireblocks API Key
  *
- * apiSecretPath: string - Fireblocks API Secret key file PATH
+ * apiSecret?: string - Fireblocks API Secret key (directly as string, e.g., from environment variable)
+ *
+ * apiSecretPath?: string - Fireblocks API Secret key file PATH
+ *
+ * Note: Either apiSecret or apiSecretPath must be provided. If both are provided, apiSecret takes precedence.
  *
  * apiBaseUrl?: ApiBaseUrl | string - Fireblocks API Base URL - default production
  *
  * vaultAccountId: string | number - Fireblocks Vault Account ID
  *
  * pollingInterval?: number - Fireblocks API polling interval for tx status updates
- * 
+ *
  * waitForFireblocksConfirmation?: boolean - Whether to wait for Fireblocks confirmation before returning the transaction. Default and recommended is true.
- * 
+ *
  * feeLevel?: LOW | MEDIUM | HIGH - Fee level to use for transactions
- * 
+ *
  * logger?: pass custom logger
- * 
+ *
  * silent?: boolean - Whether to suppress logging output. Default is false, which means verbose logging is enabled.
  */
 export interface FireblocksConnectionAdapterConfig {
   readonly apiKey: string;
-  readonly apiSecretPath: string;
+  readonly apiSecret?: string;
+  readonly apiSecretPath?: string;
   readonly apiBaseUrl?: ApiBaseUrl | string;
   readonly vaultAccountId: string | number;
   devnet?: boolean;


### PR DESCRIPTION
## Summary

- Add `apiSecret` config option to allow passing the Fireblocks API secret key directly as a string
- Make `apiSecretPath` optional when `apiSecret` is provided
- Update validation to require either `apiSecret` or `apiSecretPath`
- If both are provided, `apiSecret` takes precedence

This enables usage with secrets managers like gopass, HashiCorp Vault, or direct environment variables without needing to write secrets to the filesystem.

## Usage

```typescript
// Option 1: Direct secret (e.g., from gopass, vault, env var)
const adapter = await FireblocksConnectionAdapter.create(endpoint, {
  apiKey: process.env.FIREBLOCKS_API_KEY!,
  apiSecret: process.env.FIREBLOCKS_SECRET_KEY,  // or: execSync('gopass show fireblocks/api-secret').toString()
  vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID!,
});

// Option 2: File path (existing behavior, still supported)
const adapter = await FireblocksConnectionAdapter.create(endpoint, {
  apiKey: process.env.FIREBLOCKS_API_KEY!,
  apiSecretPath: process.env.FIREBLOCKS_SECRET_KEY_PATH!,
  vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID!,
});
```

## Test plan

- [ ] Verify adapter works with `apiSecret` provided directly
- [ ] Verify adapter still works with `apiSecretPath` (backward compatible)
- [ ] Verify error is thrown when neither `apiSecret` nor `apiSecretPath` is provided
- [ ] Verify `apiSecret` takes precedence when both are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)